### PR TITLE
Auth API handling

### DIFF
--- a/lib/DataFetcher.dart
+++ b/lib/DataFetcher.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:http/http.dart' as http;
 
 import 'LocalKeyValuePersistence.dart';
 import 'entities/course/BaseCourseData.dart';
@@ -11,6 +12,29 @@ import 'entities/user/SemesterData.dart';
 import 'entities/user/UserData.dart';
 
 class DataFetcher {
+  static String _api = 'http://snf-872013.vm.okeanos.grnet.gr:3000/';
+
+  static String token = '';
+  static String refresh = '';
+
+  static Future<bool> doAuth(
+    String email,
+    String pwd,
+    bool isLogin,
+  ) async {
+    var res = await http.post(
+      _api + (isLogin ? "auth/login/" : "auth/signup/"),
+      body: {'email': email, 'password': pwd},
+    );
+    if (res.statusCode != 200 && res.statusCode != 201) {
+      return false;
+    }
+    var json = jsonDecode(res.body);
+    token = json["token"];
+    refresh = json["refreshToken"];
+    return true;
+  }
+
   static List<PredictedCourse> fetchPredictedCourses() {
     // To be implemented for data fetching
     return new List();

--- a/lib/pages/authentication/AuthPage.dart
+++ b/lib/pages/authentication/AuthPage.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import '../../DataFetcher.dart';
 import '../../Router.dart';
 import '../../bloc/auth/exports.dart';
 import '../AbstractPage.dart';
@@ -110,14 +111,9 @@ class _AuthPageState extends PageState<AuthPage> {
     _pwdNode.unfocus();
   }
 
-  bool _doAuth() {
-    // TODO(sakis): Implement authentication flow
+  Future<bool> _doAuth() async {
     // TODO save data to disk
-    if (widget.isLogIn) {
-      return true;
-    } else {
-      return true;
-    }
+    return DataFetcher.doAuth(_email, _pwd, widget.isLogIn);
   }
 
   void _doValidate() {
@@ -126,15 +122,17 @@ class _AuthPageState extends PageState<AuthPage> {
     final FormState form = _formKey.currentState;
     form.save();
     if (form.validate()) {
-      if (_doAuth()) {
-        BlocProvider.of<AuthBloc>(context).add(AuthSuccess());
-        if (!widget.isLogIn) {
-          Router.push(context, "/form/personal");
+      _doAuth().then((succ) {
+        if (succ) {
+          BlocProvider.of<AuthBloc>(context).add(AuthSuccess());
+          if (!widget.isLogIn) {
+            Router.push(context, "/form/personal");
+          }
+        } else {
+          _scfKey.currentState.hideCurrentSnackBar();
+          _scfKey.currentState.showSnackBar(error);
         }
-      } else {
-        _scfKey.currentState.hideCurrentSnackBar();
-        _scfKey.currentState.showSnackBar(error);
-      }
+      });
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -234,12 +234,12 @@ packages:
     source: hosted
     version: "0.14.0+3"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.0+3"
+    version: "0.12.0+4"
   http_multi_server:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   shared_preferences: ^0.5.6
   connectivity: ^0.4.6+1
   json_annotation: ^3.0.1
+  http: ^0.12.0+4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR introduces the API functionality needed for a user to log in/sign up.

The app communicates with the server through a POST request and retrieves two tokens upon success.

This can be extended when persistence is implemented so that we automatically check whether the tokens stored are valid, in order to bypass the auth screen on subsequent app launches.