### PR TITLE
Persistent login + history

### DIFF
--- a/lib/DataFetcher.dart
+++ b/lib/DataFetcher.dart
@@ -1,4 +1,6 @@
 import 'dart:convert';
+import 'dart:io';
+
 import 'package:http/http.dart' as http;
 
 import 'LocalKeyValuePersistence.dart';
@@ -32,7 +34,23 @@ class DataFetcher {
     var json = jsonDecode(res.body);
     token = json["token"];
     refresh = json["refreshToken"];
+    LocalKeyValuePersistence.setUserToken(token);
+    LocalKeyValuePersistence.setRefreshToken(refresh);
     return true;
+  }
+
+  static Future<bool> localAuth(lToken, lRefresh) async {
+    token = lToken;
+    refresh = lRefresh;
+    if (token != null && refresh != null) {
+      var res = await http.get(_api + "user/profile",
+          headers: {HttpHeaders.authorizationHeader: "Bearer $token"});
+      if (res.statusCode != 200 && res.statusCode != 201) {
+        return false;
+      }
+      return true;
+    }
+    return false;
   }
 
   static List<PredictedCourse> fetchPredictedCourses() {
@@ -200,19 +218,5 @@ class DataFetcher {
         match: 55,
       ),
     ];
-  }
-
-  // Please use this function for loading user data from local storage
-  static fetchLocalUserData() async {
-    final UserData userData = await LocalKeyValuePersistence.getUserData();
-    print(userData.toJson());
-    return userData;
-  }
-
-  // Please use this function for loading list suggested courses from local storage
-  static fetchLocalSuggestedCourses() async {
-    List<SuggestedCourseData> suggestedCourses =
-        await LocalKeyValuePersistence.getListSuggestedCourses();
-    print(jsonEncode(suggestedCourses));
   }
 }

--- a/lib/LocalKeyValuePersistence.dart
+++ b/lib/LocalKeyValuePersistence.dart
@@ -15,6 +15,8 @@ class LocalKeyValuePersistence {
   static final String _userData = "userData";
   static final String _suggestedCourses = "suggestedCourses";
   static final String _predictedCourses = "predictedCourses";
+  static final String _token = "token";
+  static final String _refreshToken = "refreshToken";
 
   static setTheme(bool value) async {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
@@ -37,6 +39,38 @@ class LocalKeyValuePersistence {
     NotifState notifState =
         new NotifState(hasSemester: hasSemester, hasGrades: hasGrades);
     return prefs.setString(_notifState, jsonEncode(notifState));
+  }
+
+  static setUserToken(String token) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    return prefs.setString(_token, token);
+  }
+
+  static setRefreshToken(String refreshToken) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    return prefs.setString(_refreshToken, refreshToken);
+  }
+
+  static getUserToken() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    if (prefs.containsKey(_token)) {
+      return (prefs.getString(_token));
+    }
+    return null;
+  }
+
+  static getRefreshToken() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    if (prefs.containsKey(_refreshToken)) {
+      return (prefs.getString(_refreshToken));
+    }
+    return null;
+  }
+
+  static deleteTokens() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    prefs.remove(_token);
+    prefs.remove(_refreshToken);
   }
 
   static Future<NotifState> getNotifState() async {
@@ -98,5 +132,4 @@ class LocalKeyValuePersistence {
     }
     return DataFetcher.fetchDefaultPredictedCourses();
   }
-
 }

--- a/lib/LocalKeyValuePersistence.dart
+++ b/lib/LocalKeyValuePersistence.dart
@@ -17,6 +17,7 @@ class LocalKeyValuePersistence {
   static final String _predictedCourses = "predictedCourses";
   static final String _token = "token";
   static final String _refreshToken = "refreshToken";
+  static final String _searchHistory = "searchHistory";
 
   static setTheme(bool value) async {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
@@ -131,5 +132,40 @@ class LocalKeyValuePersistence {
       return courseData;
     }
     return DataFetcher.fetchDefaultPredictedCourses();
+  }
+
+  static updateSearchHistory(String element) async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    if (prefs.containsKey(_searchHistory)) {
+      List<String> history = prefs.getStringList(_searchHistory);
+      if (!history.contains(element)) {
+        if (history.length >= 10) {
+          history.removeAt(0);
+        }
+        history.add(element);
+        prefs.setStringList(_searchHistory, history);
+      }
+    } else {
+      prefs.setStringList(_searchHistory, [element]);
+    }
+  }
+
+  static Future<List<String>> getSearchHistory() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    if (prefs.containsKey(_searchHistory)) {
+      List<String> history = prefs.getStringList(_searchHistory);
+      return history;
+    } else {
+      return [];
+    }
+  }
+
+  static removeFromSearchHistory(String element) async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    if (prefs.containsKey(_searchHistory)) {
+      List<String> history = prefs.getStringList(_searchHistory);
+      history.remove(element);
+      prefs.setStringList(_searchHistory, history);
+    }
   }
 }

--- a/lib/LocalKeyValuePersistence.dart
+++ b/lib/LocalKeyValuePersistence.dart
@@ -143,8 +143,11 @@ class LocalKeyValuePersistence {
           history.removeAt(0);
         }
         history.add(element);
-        prefs.setStringList(_searchHistory, history);
+      } else {
+        history.remove(element);
+        history.add(element);
       }
+      prefs.setStringList(_searchHistory, history);
     } else {
       prefs.setStringList(_searchHistory, [element]);
     }

--- a/lib/bloc/auth/auth_bloc.dart
+++ b/lib/bloc/auth/auth_bloc.dart
@@ -5,8 +5,18 @@ import 'package:bloc/bloc.dart';
 import 'exports.dart';
 
 class AuthBloc extends Bloc<AuthEvent, AuthState> {
+  final String token;
+  final String refresh;
+
+  AuthBloc(this.token, this.refresh);
+
   @override
-  AuthState get initialState => NoAuth();
+  AuthState get initialState {
+    if (this.token != null && this.refresh != null) {
+      return Verified();
+    }
+    return NoAuth();
+  }
 
   @override
   Stream<AuthState> mapEventToState(AuthEvent event) async* {

--- a/lib/bloc/search/search_event.dart
+++ b/lib/bloc/search/search_event.dart
@@ -1,3 +1,4 @@
+import 'package:grade_plus_plus/LocalKeyValuePersistence.dart';
 import 'package:meta/meta.dart';
 
 @immutable
@@ -7,9 +8,14 @@ abstract class SearchEvent {
 }
 
 class CourseTapEvent extends SearchEvent {
-  CourseTapEvent(String label) : super(label);
+  CourseTapEvent(String label) : super(label){
+    LocalKeyValuePersistence.updateSearchHistory(label);
+  }
 }
 
 class HistoryDeleteEvent extends SearchEvent {
-  HistoryDeleteEvent(String label) : super(label);
+  HistoryDeleteEvent(String label) : super(label) {
+    LocalKeyValuePersistence.removeFromSearchHistory(label);
+  }
+
 }

--- a/lib/bloc/search/search_event.dart
+++ b/lib/bloc/search/search_event.dart
@@ -4,12 +4,15 @@ import 'package:meta/meta.dart';
 @immutable
 abstract class SearchEvent {
   SearchEvent(this.label);
+
   final String label;
 }
 
 class CourseTapEvent extends SearchEvent {
-  CourseTapEvent(String label) : super(label){
-    LocalKeyValuePersistence.updateSearchHistory(label);
+  CourseTapEvent(String label, bool save) : super(label) {
+    if (save) {
+      LocalKeyValuePersistence.updateSearchHistory(label);
+    }
   }
 }
 
@@ -17,5 +20,4 @@ class HistoryDeleteEvent extends SearchEvent {
   HistoryDeleteEvent(String label) : super(label) {
     LocalKeyValuePersistence.removeFromSearchHistory(label);
   }
-
 }

--- a/lib/bloc/search/search_state.dart
+++ b/lib/bloc/search/search_state.dart
@@ -4,7 +4,7 @@ import 'package:meta/meta.dart';
 abstract class SearchState {
   SearchState(this.history);
 
-  final List<String> history;
+  List<String> history;
 }
 
 class InitSearchState extends SearchState {

--- a/lib/pages/authentication/AuthPage.dart
+++ b/lib/pages/authentication/AuthPage.dart
@@ -112,7 +112,6 @@ class _AuthPageState extends PageState<AuthPage> {
   }
 
   Future<bool> _doAuth() async {
-    // TODO save data to disk
     return DataFetcher.doAuth(_email, _pwd, widget.isLogIn);
   }
 

--- a/lib/pages/fragments/SearchBar.dart
+++ b/lib/pages/fragments/SearchBar.dart
@@ -100,7 +100,8 @@ class _SearchBarState extends State<SearchBar> {
   }
 
   void _loadHistory() {
-    Future<List<dynamic>> lHistory = LocalKeyValuePersistence.getSearchHistory();
+    Future<List<dynamic>> lHistory =
+        LocalKeyValuePersistence.getSearchHistory();
     setState(() {
       history = lHistory;
     });
@@ -176,7 +177,6 @@ class _SearchBarState extends State<SearchBar> {
         );
       },
     );
-
   }
 }
 
@@ -211,7 +211,6 @@ class SearchTile extends StatelessWidget {
             if (isHist && label != DEFAULT_LABEL)
               GestureDetector(
                 onTap: () {
-//                  LocalKeyValuePersistence.removeFromSearchHistory(label);
                   BlocProvider.of<SearchBloc>(context)
                       .add(HistoryDeleteEvent(label));
                 },

--- a/lib/pages/fragments/SearchBar.dart
+++ b/lib/pages/fragments/SearchBar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import '../../LocalKeyValuePersistence.dart';
 import '../../bloc/search/exports.dart';
 import 'IconLabelPair.dart';
 
@@ -27,7 +28,14 @@ class SearchBar extends StatefulWidget {
 class _SearchBarState extends State<SearchBar> {
   final controller = TextEditingController();
   final results = Set<SearchTile>();
+  Future<List<String>> history;
   bool showHist = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadHistory();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -91,6 +99,13 @@ class _SearchBarState extends State<SearchBar> {
     });
   }
 
+  void _loadHistory() {
+    Future<List<dynamic>> lHistory = LocalKeyValuePersistence.getSearchHistory();
+    setState(() {
+      history = lHistory;
+    });
+  }
+
   Widget _buildBar() {
     return Container(
       decoration: BoxDecoration(
@@ -122,22 +137,46 @@ class _SearchBarState extends State<SearchBar> {
         children: widget.suggestions.map((str) => getTile(str)).toList(),
       );
     }
-    final history = BlocProvider.of<SearchBloc>(context).state.history;
-    if (history.isEmpty) {
-      return SearchTile(
-        label: DEFAULT_LABEL,
-        tileIcon: widget.tileIcon,
-        isHist: true,
-        onTap: null,
-      );
-    }
-    return Column(
-      children: history
-          .map((str) => getTile(str, isHist: true))
-          .toList()
-          .reversed
-          .toList(),
+    return FutureBuilder(
+      future: history,
+      builder: (BuildContext context, AsyncSnapshot<List<String>> snapshot) {
+        if (snapshot.hasData) {
+          BlocProvider.of<SearchBloc>(context).state.history = snapshot.data;
+          final history = BlocProvider.of<SearchBloc>(context).state.history;
+          if (history.isEmpty) {
+            return SearchTile(
+              label: DEFAULT_LABEL,
+              tileIcon: widget.tileIcon,
+              isHist: true,
+              onTap: null,
+            );
+          } else {
+            return Column(
+              children: history
+                  .map((str) => getTile(str, isHist: true))
+                  .toList()
+                  .reversed
+                  .toList(),
+            );
+          }
+        } else if (snapshot.hasError) {
+          // This is not tested
+
+        } else {
+          return CircularProgressIndicator(
+            backgroundColor: Colors.blue,
+            strokeWidth: 5,
+          );
+        }
+        return SearchTile(
+          label: DEFAULT_LABEL,
+          tileIcon: widget.tileIcon,
+          isHist: true,
+          onTap: null,
+        );
+      },
     );
+
   }
 }
 
@@ -172,6 +211,7 @@ class SearchTile extends StatelessWidget {
             if (isHist && label != DEFAULT_LABEL)
               GestureDetector(
                 onTap: () {
+//                  LocalKeyValuePersistence.removeFromSearchHistory(label);
                   BlocProvider.of<SearchBloc>(context)
                       .add(HistoryDeleteEvent(label));
                 },

--- a/lib/pages/search/Search.dart
+++ b/lib/pages/search/Search.dart
@@ -16,11 +16,12 @@ class Search extends AbstractPage {
           appBarTitle: "Search",
           navIcon: Icons.search,
         );
+
   _SearchState createState() => _SearchState();
 }
 
 class _SearchState extends PageState<Search> {
-  final history = Set<String>();
+//  final history = Set<String>();
   final searchMap = {
     "Linear Algebra": "ABC-01-01",
     "Algebra 1": "BXY-01-01",

--- a/lib/pages/search/Search.dart
+++ b/lib/pages/search/Search.dart
@@ -62,7 +62,7 @@ class _SearchState extends PageState<Search> {
     return SearchBar(
       searchSet: searchMap.keys.toSet(),
       onTap: (str) {
-        BlocProvider.of<SearchBloc>(context).add(CourseTapEvent(str));
+        BlocProvider.of<SearchBloc>(context).add(CourseTapEvent(str,true));
         Router.push(context, '/course', args: _getData(str, searchMap[str]));
       },
     );

--- a/lib/pages/settings/Settings.dart
+++ b/lib/pages/settings/Settings.dart
@@ -121,8 +121,8 @@ class _SettingsState extends PageState<Settings> {
                     name: 'Missing Grades',
                     icon: Icons.warning,
                     toggle: (bool gradesOn) {
-                      notifBloc.add(
-                          gradesOn ? SubToGrades() : UnsubFromGrades());
+                      notifBloc
+                          .add(gradesOn ? SubToGrades() : UnsubFromGrades());
                       LocalKeyValuePersistence.setNotifState(
                           notifState.getHasSemester(), gradesOn);
                     },
@@ -145,7 +145,10 @@ class _SettingsState extends PageState<Settings> {
           label: 'Log Out',
           icon: Icons.exit_to_app,
           color: Colors.red.shade500,
-          onTap: () => BlocProvider.of<AuthBloc>(context).add(LogOut()),
+          onTap: () {
+            LocalKeyValuePersistence.deleteTokens();
+            BlocProvider.of<AuthBloc>(context).add(LogOut());
+          },
         ),
       ],
     );


### PR DESCRIPTION
This commit persists the user's token and refresh and course history from the search page.

**Login Tokens**
- Loads on startup
- Sets them to DataFetcher
- Checks with the server if they are valid by requesting its profile (/user/profile)

**Search History**
- Saves up to 10 courses
- If a course exists in list reorders it on top
- The oldest course is deleted if maximum length (10) is reached