### PR TITLE
Add loading indicator fragment

### DIFF
--- a/lib/pages/HomeScreen.dart
+++ b/lib/pages/HomeScreen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:grade_plus_plus/LocalKeyValuePersistence.dart';
 
 import '../LocalKeyValuePersistence.dart';
 import '../entities/course/PredictedCourse.dart';
@@ -7,6 +6,9 @@ import '../entities/course/SuggestedCourseData.dart';
 import '../entities/user/UserData.dart';
 import 'AbstractPage.dart';
 import 'course_suggest/CourseSuggest.dart';
+import 'fragments/BlankPadding.dart';
+import 'fragments/LoadingIndicator.dart';
+import 'fragments/StyledText.dart';
 import 'grade_predict/GradePredict.dart';
 import 'search/Search.dart';
 import 'settings/Settings.dart';
@@ -105,17 +107,19 @@ class _HomeScreenState extends State<HomeScreen> {
             )
           ];
         } else {
-          // TODO This needs ui fixing
-          return CircularProgressIndicator(
-            backgroundColor: Colors.blue,
-            strokeWidth: 5,
-          );
+          children = [
+            LoadingIndicator(),
+            BlankPadding(),
+            StyledText("Loading..."),
+          ];
         }
-        return Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: children,
+        return Scaffold(
+          body: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: children,
+            ),
           ),
         );
       },

--- a/lib/pages/fragments/LoadingIndicator.dart
+++ b/lib/pages/fragments/LoadingIndicator.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+class LoadingIndicator extends CircularProgressIndicator {
+  LoadingIndicator()
+      : super(
+          backgroundColor: Colors.blue.withOpacity(0.1),
+          strokeWidth: 5,
+        );
+}

--- a/lib/pages/fragments/SearchBar.dart
+++ b/lib/pages/fragments/SearchBar.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../LocalKeyValuePersistence.dart';
 import '../../bloc/search/exports.dart';
 import 'IconLabelPair.dart';
+import 'LoadingIndicator.dart';
 
 const String DEFAULT_LABEL = "Your history will show up here.";
 
@@ -164,10 +165,7 @@ class _SearchBarState extends State<SearchBar> {
           // This is not tested
 
         } else {
-          return CircularProgressIndicator(
-            backgroundColor: Colors.blue,
-            strokeWidth: 5,
-          );
+          return LoadingIndicator();
         }
         return SearchTile(
           label: DEFAULT_LABEL,


### PR DESCRIPTION
With this PR, the loading indicator, which is present on the home page and in place of the search history while the Future has no data, is fixed to display properly .This was done by adding a Scaffold around the Center container that used to hold the widget.

Screenshot (the real one is actually spinning):
![loading](https://user-images.githubusercontent.com/8458550/77657634-3e4cbb80-6f7e-11ea-9275-b7e5628abd4b.jpg)
