### PR TITLE
Use dio for connection handling

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -261,13 +261,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.14.0+3"
-  http:
-    dependency: "direct main"
-    description:
-      name: http
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.12.0+4"
   http_multi_server:
     dependency: transitive
     description:
@@ -545,7 +538,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.2.11"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   shared_preferences: ^0.5.6
   connectivity: ^0.4.6+1
   json_annotation: ^3.0.1
-  http: ^0.12.0+4
+  dio: ^3.0.9
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
With this PR I've switched over to using the dio package for HTTP requests.

The way that dio works is that it throws an exception whenever we either get no response or one with an error status code. So what we have to do in every request is surround it in try/catch and in the case where there is an exception, it means that the request wasn't fulfilled by the server so we should show an error to the user.

With these changes, when there's no internet connectivity, the app should now be fully using the cached data when there are any. If the user wasn't connected, they'll be redirected to the login screen where they'll get an error for "Invalid credentials" since we cannot verify them without a connection to the server.