### PR TITLE
Show proper error on signup page

### DIFF
--- a/lib/pages/authentication/AuthPage.dart
+++ b/lib/pages/authentication/AuthPage.dart
@@ -47,10 +47,10 @@ class _AuthPageState extends PageState<AuthPage> {
   final FocusNode _pwdNode = FocusNode();
   final FocusNode _pwdConfirmNode = FocusNode();
 
-  final SnackBar error = SnackBar(
-    content: const Text('Invalid Credentials!'),
-    backgroundColor: Colors.redAccent,
-  );
+  SnackBar error(String str) => SnackBar(
+        content: Text(str),
+        backgroundColor: Colors.redAccent,
+      );
 
   @override
   Widget body(GlobalKey<ScaffoldState> scfKey) {
@@ -123,7 +123,11 @@ class _AuthPageState extends PageState<AuthPage> {
           }
         } else {
           _scfKey.currentState.hideCurrentSnackBar();
-          _scfKey.currentState.showSnackBar(error);
+          _scfKey.currentState.showSnackBar(
+            error(widget.isLogIn
+                ? 'Invalid Credentials!'
+                : 'Email already exists!'),
+          );
         }
       });
     }


### PR DESCRIPTION
Previously, the signup page would show the error `Invalid Credentials` when something went wrong on both the login and the signup page. This has now been changed to `Email already exists` for the latter.

PS: We should maybe check in the future if the cause of the error is something else and show that instead?