### PR TITLE
Use JDK11 for the GH Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-java@v1
       with:
-        java-version: '12.x'
+        java-version: '11.x'
     - uses: subosito/flutter-action@v1
       with:
         channel: 'stable'


### PR DESCRIPTION
The default setup uses Java 12 for some reason, which I'm assuming has issues with Flutter 2.

Locally I've been able to build with JDK11 so this should fix the error.