### PR TITLE
Refresh token implementation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,18 +20,13 @@ void main() async {
       .getNotifState(); // Getting the notification preferences
   String token = await LocalKeyValuePersistence.getUserToken();
   String refresh = await LocalKeyValuePersistence.getRefreshToken();
-  DataFetcher.localAuth(token, refresh).then((succ) {
-    if (!succ) {
-      token = null;
-      refresh = null;
-    }
-  });
-
+  await DataFetcher.localAuth(token, refresh);
   runApp(MyApp(
-      initialThemeState: initialThemeState,
-      initialNotifState: initialNotifState,
-      token: token,
-      refresh: refresh));
+    initialThemeState: initialThemeState,
+    initialNotifState: initialNotifState,
+    token: token,
+    refresh: refresh,
+  ));
 }
 
 class MyApp extends StatefulWidget {
@@ -59,36 +54,28 @@ class _MyAppState extends State<MyApp> {
   final String token;
   final String refresh;
   final ThemeData lightTheme = ThemeData(
-    accentColor: Colors.lightBlue,
-    appBarTheme: AppBarTheme(
-      color: Colors.lightBlue.shade600,
-      elevation: 0.20,
-      textTheme: TextTheme(
-        title: TextStyle(
-          color: Colors.white,
-          fontWeight: FontWeight.bold,
-          fontSize: 20,
+      accentColor: Colors.lightBlue,
+      appBarTheme: AppBarTheme(
+        color: Colors.lightBlue.shade600,
+        elevation: 0.20,
+        textTheme: TextTheme(
+          title: TextStyle(
+            color: Colors.white,
+            fontWeight: FontWeight.bold,
+            fontSize: 20,
+          ),
         ),
       ),
-    ),
-    backgroundColor: Colors.white,
-    cardColor: Colors.lightBlue[50],
-    bottomAppBarColor: Colors.lightBlue.shade600,
-    brightness: Brightness.light,
-    primarySwatch: Colors.blue,
-    textTheme: TextTheme(
-      title: TextStyle(
-        color: Colors.blue.shade600
-      ),
-      subtitle: TextStyle(
-        color: Colors.blue.shade600
-      ),
-      body1: TextStyle(
-       color: Colors.blue.shade600
-      )
-
-    )
-  );
+      backgroundColor: Colors.white,
+      cardColor: Colors.lightBlue[50],
+      bottomAppBarColor: Colors.lightBlue.shade600,
+      brightness: Brightness.light,
+      primarySwatch: Colors.blue,
+      textTheme: TextTheme(
+        title: TextStyle(color: Colors.blue.shade600),
+        subtitle: TextStyle(color: Colors.blue.shade600),
+        body1: TextStyle(color: Colors.blue.shade600),
+      ));
   final ThemeData darkTheme = ThemeData(
     accentColor: Colors.lightBlue,
     appBarTheme: AppBarTheme(

--- a/lib/pages/HomeScreen.dart
+++ b/lib/pages/HomeScreen.dart
@@ -38,44 +38,30 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   void initState() {
     super.initState();
-//
 
     courses = DataFetcher.fetchCourses();
     teachers = DataFetcher.fetchTeachers();
     userData = DataFetcher.fetchUserData();
     predictedCourses = DataFetcher.fetchPredictedCourses();
-
-
-    _loadLocalData(); // See the to-do below
-  }
-
-  _loadLocalData() {
-    // TODO: We can implement this inside their call in data fetcher as the DataFetcher.fetchCourses is implemented
-    Future<List<dynamic>> sc =
-        LocalKeyValuePersistence.getListSuggestedCourses();
-
-    setState(() {
-      suggestedCourses = sc;
-    });
+    suggestedCourses = DataFetcher.fetchSuggestedCourses();
   }
 
   @override
   Widget build(BuildContext context) {
     return FutureBuilder(
       future: Future.wait(
-              [userData, suggestedCourses, predictedCourses, courses, teachers])
-          .then(
-        (response) => new Merged(
+        [userData, suggestedCourses, predictedCourses, courses, teachers],
+      ).then((response) => new Merged(
             userData: response[0],
             suggestedCourses: response[1],
             predictedCourses: response[2],
             courses: response[3],
-            teachers: response[4]),
-      ),
+            teachers: response[4],
+          )),
       builder: (BuildContext context, AsyncSnapshot<Merged> snapshot) {
         List<Widget> children;
         if (snapshot.hasData) {
-          if (snapshot.data.userData.name == null){
+          if (snapshot.data.userData.name == null) {
             return PersonalForm();
           }
           pages = <AbstractPage>[
@@ -159,10 +145,11 @@ class Merged {
   final HashMap<String, Course> courses;
   final HashMap<String, Teacher> teachers;
 
-  Merged(
-      {this.userData,
-      this.suggestedCourses,
-      this.predictedCourses,
-      this.courses,
-      this.teachers});
+  Merged({
+    this.userData,
+    this.suggestedCourses,
+    this.predictedCourses,
+    this.courses,
+    this.teachers,
+  });
 }


### PR DESCRIPTION
This PR introduces the functionality needed for the refresh token to be used when the ephemeral token expires (currently set to 1 day by the server).

The way we do this is by sending a GET request to the `/user/profile/` endpoint upon launching the app (called in the **localAuth** function in DataFetcher). If this request succeeds, then the normal token is fine to use. However, if it fails, we can send another request to the `/auth/token` endpoint to request a new token. It's possible that the latter request fails as well, if the refresh token has also expired (~1 month), in which case the user must go through the log in process again with their email and password.